### PR TITLE
Add personal site and FenBench page

### DIFF
--- a/fenbench/index.html
+++ b/fenbench/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>FenBench</title>
+  <link href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="static/css/style.css">
+</head>
+<body>
+  <nav class="nav">
+    <a href="/">Home</a>
+    <a href="https://x.com/PucciBets">Twitter</a>
+  </nav>
+  <section class="hero">
+    <div class="hero-body">
+      <div class="container has-text-centered">
+        <h1 class="title is-1">FenBench</h1>
+        <h2 class="subtitle is-3">A simple benchmark for chess engine evaluation</h2>
+      </div>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container">
+      <h2 class="title is-3">Introduction</h2>
+      <p>FenBench is an upcoming evaluation suite for chess engines based on FEN positions. This project is inspired by the clean design of <a href="https://simple-bench.com/">SimpleBench</a>.</p>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container leaderboard">
+      <h2 class="title is-3">Leaderboard</h2>
+      <table id="leaderboardTable">
+        <tr>
+          <th>Rank</th>
+          <th>Engine</th>
+          <th>Score</th>
+          <th>Organization</th>
+        </tr>
+      </table>
+      <button class="settings-button" onclick="toggleSettings()">benchmark settings</button>
+      <div id="settingsInfo" class="settings-info">
+        FEN depth: 20, time limit: 1s per move
+      </div>
+    </div>
+  </section>
+  <footer class="footer">
+    <div class="content has-text-centered">
+      <p>Contact <a href="https://x.com/PucciBets">@PucciBets</a> for more information.</p>
+    </div>
+  </footer>
+  <script src="static/js/index.js"></script>
+</body>
+</html>

--- a/fenbench/static/css/style.css
+++ b/fenbench/static/css/style.css
@@ -1,0 +1,55 @@
+body {
+  font-family: 'Noto Sans', sans-serif;
+  padding: 20px;
+  background-color: #FFFFFF;
+  color: #000000;
+}
+
+h1, h2 {
+  text-align: center;
+  color: #333333;
+}
+
+.leaderboard {
+  max-width: 800px;
+  margin: 0 auto;
+  margin-top: 20px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+  box-shadow: 0 0 20px rgba(200, 200, 200, 0.3);
+}
+
+th, td {
+  padding: 12px;
+  text-align: left;
+  border-bottom: 1px solid #dddddd;
+}
+
+th {
+  background-color: #f2f2f2;
+  color: #333333;
+}
+
+tr:nth-child(even) {
+  background-color: #f9f9f9;
+}
+
+.rank {
+  font-weight: bold;
+  color: #0077B6;
+}
+
+.nav a {
+  color: #0077B6;
+  text-decoration: none;
+  margin: 0 10px;
+  font-weight: bold;
+}
+
+.nav a:hover {
+  color: #005f86;
+}

--- a/fenbench/static/js/index.js
+++ b/fenbench/static/js/index.js
@@ -1,0 +1,28 @@
+function toggleSettings() {
+  const settingsInfo = document.getElementById('settingsInfo');
+  if (settingsInfo.style.display === 'none' || settingsInfo.style.display === '') {
+    settingsInfo.style.display = 'block';
+  } else {
+    settingsInfo.style.display = 'none';
+  }
+}
+
+function populateLeaderboard() {
+  const data = [
+    {rank: '1st', model: 'Stockfish 16', score: '3500', organization: 'Open Source'},
+    {rank: '2nd', model: 'Lc0', score: '3400', organization: 'Open Source'},
+    {rank: '3rd', model: 'Komodo', score: '3300', organization: 'Komodo Chess'},
+  ];
+  const table = document.getElementById('leaderboardTable');
+  data.forEach(entry => {
+    const row = table.insertRow();
+    row.innerHTML = `
+      <td class="rank">${entry.rank}</td>
+      <td>${entry.model}</td>
+      <td>${entry.score}</td>
+      <td>${entry.organization}</td>
+    `;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', populateLeaderboard);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PucciBets</title>
+  <link href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css" rel="stylesheet">
+</head>
+<body>
+  <section class="hero is-primary is-fullheight">
+    <div class="hero-body">
+      <div class="container has-text-centered">
+        <h1 class="title">PucciBets</h1>
+        <h2 class="subtitle">Welcome to my project page</h2>
+        <p><a href="https://x.com/PucciBets">Follow me on X (Twitter)</a></p>
+        <p><a href="/fenbench">Visit FenBench &raquo;</a></p>
+      </div>
+    </div>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add root page with Twitter link and FenBench link
- add /fenbench subsite styled like SimpleBench
- include minimal leaderboard

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684998aa11208329b3dabafd206c7431